### PR TITLE
Add Dockerfile and update README.md with instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# Use the official PHP image as the base image
+FROM php:7.4-cli
+
+# Copy the proxy.php file into the Docker image
+COPY proxy.php /var/www/html/proxy.php
+
+# Expose port 80 for the web server
+EXPOSE 80
+
+# Use CMD to start the PHP built-in web server
+CMD ["php", "-S", "0.0.0.0:80", "-t", "/var/www/html"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To run the project locally, you need to have PHP installed on your machine. The 
 
 1. Clone the repository:
    ```sh
-   git clone https://github.com/HomeDev68/web-proxy-script.git
+   git clone https://github.com/heiswayi/web-proxy-script.git
    cd web-proxy-script
    ```
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,39 @@
 
 A minimalist, private web proxy script written in PHP code.
 
+## Running the Project Locally
+
+To run the project locally, you need to have PHP installed on your machine. The required PHP version is 7.4 or higher. Additionally, you need to have the cURL extension enabled.
+
+1. Clone the repository:
+   ```sh
+   git clone https://github.com/HomeDev68/web-proxy-script.git
+   cd web-proxy-script
+   ```
+
+2. Start the PHP built-in web server:
+   ```sh
+   php -S localhost:8000
+   ```
+
+3. Open your web browser and navigate to `http://localhost:8000/proxy.php`.
+
+## Using Docker
+
+To build and run the Docker container, follow these steps:
+
+1. Build the Docker image:
+   ```sh
+   docker build -t web-proxy-script .
+   ```
+
+2. Run the Docker container:
+   ```sh
+   docker run -p 80:80 web-proxy-script
+   ```
+
+3. Open your web browser and navigate to `http://localhost/proxy.php`.
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
* **Dockerfile**
  - Create a Dockerfile to build a Docker image for the PHP web proxy
  - Use the official PHP image as the base image
  - Copy the `proxy.php` file into the Docker image
  - Expose port 80 for the web server
  - Use `CMD` to start the PHP built-in web server

* **README.md**
  - Add instructions for running the project locally
  - Add instructions for building and running the Docker container
  - Include example commands for both local and Docker usage
  - Mention the required PHP version and dependencies