### PR TITLE
Add the error message

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -3,6 +3,7 @@
 // Private web proxy script by Heiswayi Nrird (https://heiswayi.nrird.com)
 // Released under MIT license
 // Free Software should work like this: whatever you take for free, you must give back for free.
+
 if (!function_exists("gzcompress")) die ("This proxy requires PHP's zlib extension. Please install/enable it on your server and try again.");
 if (!function_exists("curl_init")) die ("This proxy requires PHP's cURL extension. Please install/enable it on your server and try again.");
 

--- a/proxy.php
+++ b/proxy.php
@@ -3,10 +3,10 @@
 // Private web proxy script by Heiswayi Nrird (https://heiswayi.nrird.com)
 // Released under MIT license
 // Free Software should work like this: whatever you take for free, you must give back for free.
+if (!function_exists("gzcompress")) die ("This proxy requires PHP's zlib extension. Please install/enable it on your server and try again.");
+if (!function_exists("curl_init")) die ("This proxy requires PHP's cURL extension. Please install/enable it on your server and try again.");
 
 ob_start("ob_gzhandler");
-
-if (!function_exists("curl_init")) die ("This proxy requires PHP's cURL extension. Please install/enable it on your server and try again.");
 
 //Adapted from http://www.php.net/manual/en/function.getallheaders.php#99814
 if (!function_exists("getallheaders")) {


### PR DESCRIPTION
Add the error message if zlib extension is not exists. Because "ob_start("ob_gzhandler")" will need the zlib extension.